### PR TITLE
adds circle packing chart

### DIFF
--- a/example/pack.md
+++ b/example/pack.md
@@ -23,4 +23,4 @@ new d3plus.Pack()
 
 ```
 
-Colors are assigned to each unique ID using the color [assign](http://d3plus.org/docs/#assign) function, and the circles are created using the [Circle](http://d3plus.org/docs/#Circle) class.
+Colors are assigned to each unique ID using the color [assign](http://d3plus.org/docs/#assign) function, and the bubbles are created using the [Circle](http://d3plus.org/docs/#Circle) class.

--- a/example/pack.md
+++ b/example/pack.md
@@ -23,4 +23,4 @@ new d3plus.Pack()
 
 ```
 
-Colors are assigned to each unique ID using the color [assign](http://d3plus.org/docs/#assign) function, and the rectangles are created using the [Circle](http://d3plus.org/docs/#Circle) class.
+Colors are assigned to each unique ID using the color [assign](http://d3plus.org/docs/#assign) function, and the circles are created using the [Circle](http://d3plus.org/docs/#Circle) class.

--- a/example/pack.md
+++ b/example/pack.md
@@ -1,0 +1,26 @@
+# Circle Packing Chart
+
+Given an array of data objects that looks something like this:
+
+```js
+var data = [
+  {parent: "Group 1", id: "alpha", value: 29},
+  {parent: "Group 1", id: "beta", value: 10},
+  {parent: "Group 1", id: "gamma", value: 2},
+  {parent: "Group 2", id: "delta", value: 29},
+  {parent: "Group 2", id: "eta", value: 25}
+];
+```
+
+Only a few lines of code are needed to transform it into an interactive [Pack](http://d3plus.org/docs/#Pack):
+
+```js
+new d3plus.Pack()
+  .data(data)
+  .groupBy(["parent", "id"])
+  .sum("value")
+  .render();
+
+```
+
+Colors are assigned to each unique ID using the color [assign](http://d3plus.org/docs/#assign) function, and the rectangles are created using the [Circle](http://d3plus.org/docs/#Circle) class.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export {default as Donut} from "./src/Donut";
+export {default as Pack} from "./src/Pack";
 export {default as Pie} from "./src/Pie";
 export {default as Tree} from "./src/Tree";
 export {default as Treemap} from "./src/Treemap";

--- a/src/Pack.js
+++ b/src/Pack.js
@@ -12,7 +12,7 @@ import {Viz} from "d3plus-viz";
 /**
     @class Pack
     @extends Viz
-    @desc Uses the [d3 pack layout](https://github.com/d3/d3-hierarchy#pack) to creates SVG arcs based on an array of data.
+    @desc Uses the [d3 pack layout](https://github.com/d3/d3-hierarchy#pack) to creates Circle Packing chart based on an array of data.
 */
 export default class Pack extends Viz {
 

--- a/src/Pack.js
+++ b/src/Pack.js
@@ -73,6 +73,7 @@ export default class Pack extends Viz {
 
     };
     this._pack = pack();
+    this._packOpacity = 0.25;
     this._shape = constant("Circle");
     this._shapeConfig = assign(this._shapeConfig, {
       Circle: {
@@ -119,7 +120,7 @@ export default class Pack extends Viz {
       d.parent = d.parent;
       d.x = d.x;
       d.y = d.y;
-      if (d.height) d.data.__d3plusOpacity__ = 0.25;
+      if (d.height) d.data.__d3plusOpacity__ = this._packOpacity;
     });
 
     this._shapes.push(
@@ -142,6 +143,12 @@ export default class Pack extends Viz {
     return this;
   }
 
+  /**
+      @memberof Pack
+      @desc If *value* is specified, sets the hover method to the specified function and returns the current class instance.
+      @param {Function} [*value*]
+      @chainable
+   */
   hover(_) {
     this._hover = _;
     this._shapes.forEach(s => s.hover(_));
@@ -152,11 +159,20 @@ export default class Pack extends Viz {
 
   /**
       @memberof Pack
-      @desc If *value* is specified, sets the inner and outer padding accessor to the specified function or number and returns the current class instance. If *value* is not specified, returns the current padding accessor.
+      @desc If *value* is specified, sets the opacity accessor to the specified function or number and returns the current class instance. If *value* is not specified, returns the current pack opacity accessor.
       @param {Function|Number} [*value*]
   */
   layoutPadding(_) {
     return arguments.length ? (this._layoutPadding = typeof _ === "function" ? _ : constant(_), this) : this._layoutPadding;
+  }
+
+  /**
+      @memberof Pack
+      @desc If *value* is specified, sets the padding accessor to the specified function or number and returns the current class instance. If *value* is not specified, returns the current pack opacity accessor.
+      @param {Function|Number} [*value*]
+  */
+  packOpacity(_) {
+    return arguments.length ? (this._packOpacity = typeof _ === "function" ? _ : constant(_), this) : this._packOpacity;
   }
 
   /**

--- a/src/Pack.js
+++ b/src/Pack.js
@@ -28,6 +28,7 @@ export default class Pack extends Viz {
     this._layoutPadding = 1;
     this._on.mouseenter = () => {};
     this._on["mouseleave.shape"] = () => {
+      this._tooltip = false;
       this.hover(false);
     };
 
@@ -46,7 +47,6 @@ export default class Pack extends Viz {
     const defaultMouseMove = this._on["mousemove.shape"];
     this._on["mousemove.legend"] = (d, i) => {
       const ids = this._ids(d, i);
-
       hoverData = [d];
       recursionCircles(d);
 
@@ -65,6 +65,8 @@ export default class Pack extends Viz {
     };
     this._on["mousemove.shape"] = (d, i) => {
       defaultMouseMove(d, i);
+
+      this._tooltip = d.__d3plusTooltip__;
 
       hoverData = [d];
       recursionCircles(d);
@@ -85,6 +87,7 @@ export default class Pack extends Viz {
     });
     this._sort = (a, b) => b.value - a.value;
     this._sum = accessor("value");
+    this._tooltip = false;
 
   }
 
@@ -114,6 +117,7 @@ export default class Pack extends Viz {
     packData.forEach((d, i) => {
       d.__d3plus__ = true;
       d.children = d.children;
+      d.data.__d3plusTooltip__ = !d.height ? true : false;
       d.depth = d.depth;
       d.i = i;
       d.id = d.parent ? d.parent.data.key : null;

--- a/src/Pack.js
+++ b/src/Pack.js
@@ -1,0 +1,110 @@
+/**
+    @external Viz
+    @see https://github.com/d3plus/d3plus-viz#Viz
+*/
+import {nest} from "d3-collection";
+import {hierarchy, pack} from "d3-hierarchy";
+
+import {accessor, assign, configPrep, constant, elem, merge} from "d3plus-common";
+import * as shapes from "d3plus-shape";
+import {Viz} from "d3plus-viz";
+
+/**
+    @class Pack
+    @extends Viz
+    @desc Uses the [d3 pack layout](https://github.com/d3/d3-hierarchy#pack) to creates SVG arcs based on an array of data.
+*/
+export default class Pack extends Viz {
+
+  /**
+      @memberof Pack
+      @desc Invoked when creating a new class instance, and sets any default parameters.
+      @private
+  */
+  constructor() {
+
+    super();
+
+    this._on.mouseenter = () => {};
+    this._on["mouseleave.shape"] = () => {
+      this.hover(false);
+    };
+    this._pack = pack();
+    this._shape = constant("Circle");
+    this._shapeConfig = assign(this._shapeConfig, {
+      Circle: {
+        opacity: d => d.__d3plusOpacity__ || 1,
+        labelConfig: {
+          fontResize: true
+        }
+      }
+    });
+    this._sort = (a, b) => b.value - a.value;
+    this._sum = accessor("value");
+  }
+
+  /**
+      Extends the draw behavior of the abstract Viz class.
+      @private
+  */
+  _draw(callback) {
+    super._draw(callback);
+
+    const height = this._height - this._margin.top - this._margin.bottom,
+          width = this._width - this._margin.left - this._margin.right;
+
+    const diameter = Math.min(height, width);
+    const transform = `translate(${(width - diameter) / 2}, ${(height - diameter) / 2})`;
+
+    let nestedData = nest();
+    for (let i = 0; i <= this._drawDepth; i++) nestedData.key(this._groupBy[i]);
+    nestedData = nestedData.entries(this._filteredData);
+    
+    const packData = this._pack
+      .padding(this._layoutPadding)
+      .size([diameter, diameter])
+      (hierarchy({key: nestedData.key, values: nestedData}, d => d.values).sum(this._sum).sort(this._sort))
+      .descendants();
+
+    packData.forEach((d, i) => {
+      d.__d3plus__ = true;
+      d.id = d.data.key;
+      d.depth = d.depth;
+      d.x = d.x;
+      d.y = d.y;
+      if (d.height) d.data.__d3plusOpacity__ = 0.25;
+    });
+
+    this._shapes.push(
+      new shapes.Circle()
+        .data(packData)
+        .select(
+          elem("g.d3plus-Pack-circle", {
+            parent: this._select,
+            enter: {transform},
+            update: {transform}
+          }).node()
+        )
+        .config({
+          label: d => d.parent && !d.children ? d.data.name : false
+        })
+        .config(configPrep.bind(this)(this._shapeConfig, "shape", "Circle"))
+        .render()
+    );
+
+    return this;
+  }
+
+  /**
+      @memberof Pack
+      @desc If *value* is specified, sets the sum accessor to the specified function or number and returns the current class instance. If *value* is not specified, returns the current sum accessor.
+      @param {Function|Number} [*value*]
+      @example
+function sum(d) {
+  return d.sum;
+}
+  */
+  sum(_) {
+    return arguments.length ? (this._sum = typeof _ === "function" ? _ : accessor(_), this) : this._sum;
+  }
+}

--- a/src/Pack.js
+++ b/src/Pack.js
@@ -5,7 +5,7 @@
 import {nest} from "d3-collection";
 import {hierarchy, pack} from "d3-hierarchy";
 
-import {accessor, assign, configPrep, constant, elem, merge} from "d3plus-common";
+import {accessor, assign, configPrep, constant, elem} from "d3plus-common";
 import * as shapes from "d3plus-shape";
 import {Viz} from "d3plus-viz";
 

--- a/src/Pack.js
+++ b/src/Pack.js
@@ -25,9 +25,36 @@ export default class Pack extends Viz {
 
     super();
 
+    this._layoutPadding = 1;
     this._on.mouseenter = () => {};
     this._on["mouseleave.shape"] = () => {
       this.hover(false);
+    };
+    const defaultMouseMove = this._on["mousemove.shape"];
+    this._on["mousemove.shape"] = (d, i) => {
+      defaultMouseMove(d, i);
+      console.log(d);
+      const hoverData = [d];
+      function recursion(d) {
+        if (d.values) {
+          d.values.forEach((h, x) => {
+            hoverData.push(h);
+            recursion (h);
+          });
+        }
+        else {
+          hoverData.push(d);
+        }
+      }
+
+      recursion(d);
+
+      this.hover((h, x) => {
+        if (hoverData.includes(h)) {
+          return true;
+        }
+      });
+
     };
     this._pack = pack();
     this._shape = constant("Circle");
@@ -41,6 +68,7 @@ export default class Pack extends Viz {
     });
     this._sort = (a, b) => b.value - a.value;
     this._sum = accessor("value");
+
   }
 
   /**
@@ -59,7 +87,7 @@ export default class Pack extends Viz {
     let nestedData = nest();
     for (let i = 0; i <= this._drawDepth; i++) nestedData.key(this._groupBy[i]);
     nestedData = nestedData.entries(this._filteredData);
-    
+
     const packData = this._pack
       .padding(this._layoutPadding)
       .size([diameter, diameter])
@@ -68,8 +96,11 @@ export default class Pack extends Viz {
 
     packData.forEach((d, i) => {
       d.__d3plus__ = true;
-      d.id = d.data.key;
+      d.children = d.children;
       d.depth = d.depth;
+      d.i = i;
+      d.id = d.parent ? d.parent.data.key : null;
+      d.parent = d.parent;
       d.x = d.x;
       d.y = d.y;
       if (d.height) d.data.__d3plusOpacity__ = 0.25;
@@ -86,13 +117,32 @@ export default class Pack extends Viz {
           }).node()
         )
         .config({
-          label: d => d.parent && !d.children ? d.data.name : false
+          label: (d, i) => d.parent && !d.children ? this._id(d, i) : false
         })
         .config(configPrep.bind(this)(this._shapeConfig, "shape", "Circle"))
         .render()
     );
 
     return this;
+  }
+
+  hover(_) {
+    this._hover = _;
+    this._shapes.forEach(s => s.hover(_));
+    
+    console.log(this);
+
+    if (this._legend) this._legendClass.hover(_);
+    return this;
+  }
+
+  /**
+      @memberof Pack
+      @desc If *value* is specified, sets the inner and outer padding accessor to the specified function or number and returns the current class instance. If *value* is not specified, returns the current padding accessor.
+      @param {Function|Number} [*value*]
+  */
+  layoutPadding(_) {
+    return arguments.length ? (this._layoutPadding = typeof _ === "function" ? _ : constant(_), this) : this._layoutPadding;
   }
 
   /**


### PR DESCRIPTION
Adds pack visualization (closes #39 )

### Description
<!--- Describe your changes in detail -->
This feature creates a new visualization available for d3plus. Circle packing provides other way for to visualizate hierarchy data. Using d3's algorithm base, `Pack.js` creates a chart with deep of `n`-levels in bubbles, where the size of the leaf circles encodes a quantitative dimension of the data.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [x] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

